### PR TITLE
Fix PHP 8.4 compatibility issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Updated
 - Add security check on external files imported through template.
 - Replace adminhtml and frontend urls files included through pagebuilder widget preview module or other solutions.
+### Fixed
+- Fix undefined variable $children in importTemplateChildren when no files match the pattern
+- Add return type hints to SearchResultInterface methods in Grid/Collection
 
 ## 1.6.2
 ## Updated

--- a/Model/ResourceModel/RemoteTemplate/Grid/Collection.php
+++ b/Model/ResourceModel/RemoteTemplate/Grid/Collection.php
@@ -58,79 +58,62 @@ class Collection extends RemoteTemplateCollection implements SearchResultInterfa
     }
 
     /**
-     * Get aggregations
-     *
      * @return AggregationInterface
      */
-    public function getAggregations()
+    public function getAggregations(): AggregationInterface
     {
         return $this->aggregations;
     }
 
     /**
-     * Set aggregations
-     *
      * @param AggregationInterface $aggregations
      * @return $this
      */
-    public function setAggregations($aggregations)
+    public function setAggregations(AggregationInterface $aggregations): Collection
     {
         $this->aggregations = $aggregations;
         return $this;
     }
 
     /**
-     * Get search criteria.
-     *
-     * @return \Magento\Framework\Api\SearchCriteriaInterface|null
+     * @return SearchCriteriaInterface|null
      */
-    public function getSearchCriteria()
+    public function getSearchCriteria(): ?SearchCriteriaInterface
     {
         return null;
     }
 
     /**
-     * Set search criteria.
-     *
-     * @param SearchCriteriaInterface $searchCriteria
+     * @param SearchCriteriaInterface|null $searchCriteria
      * @return $this
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setSearchCriteria(?SearchCriteriaInterface $searchCriteria = null)
+    public function setSearchCriteria(?SearchCriteriaInterface $searchCriteria = null): Collection
     {
         return $this;
     }
 
     /**
-     * Get total count.
-     *
      * @return int
      */
-    public function getTotalCount()
+    public function getTotalCount(): int
     {
         return $this->getSize();
     }
 
     /**
-     * Set total count.
-     *
      * @param int $totalCount
      * @return $this
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setTotalCount($totalCount)
+    public function setTotalCount(int $totalCount): Collection
     {
         return $this;
     }
 
     /**
-     * Set items list.
-     *
-     * @param ExtensibleDataInterface[] $items
+     * @param array|null $items
      * @return $this
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function setItems(?array $items = null)
+    public function setItems(?array $items = null): Collection
     {
         return $this;
     }

--- a/Model/TemplateManagement.php
+++ b/Model/TemplateManagement.php
@@ -523,6 +523,7 @@ class TemplateManagement implements TemplateManagementInterface
 
         // Scan the folder
         $files = scandir($childrenFolderPath);
+        $children = [];
 
         foreach ($files as $file) {
             // Skip non-files


### PR DESCRIPTION
## Summary

Fix two PHP 8.4 compatibility issues:

- **TemplateManagement.php**: initialize  array before the foreach loop in importTemplateChildren() to prevent Undefined variable warning and TypeError on usort() when no files match the expected pattern
- **Grid/Collection.php**: add missing return type hints and parameter type hints to all SearchResultInterface methods (getAggregations, setAggregations, getSearchCriteria, setSearchCriteria, getTotalCount, setTotalCount, setItems)

## Note

@rhoerr There are also several commits on master after the 1.6.3 tag that are not yet released. It might be a good time to tag 1.7.0 including both the previous untagged changes and this PHP 8.4 fix.