### PR TITLE
Fix PHP 8.4 incompatible signature on Grid Collection setAggregations/setTotalCount

### DIFF
--- a/Model/ResourceModel/RemoteTemplate/Grid/Collection.php
+++ b/Model/ResourceModel/RemoteTemplate/Grid/Collection.php
@@ -69,7 +69,7 @@ class Collection extends RemoteTemplateCollection implements SearchResultInterfa
      * @param AggregationInterface $aggregations
      * @return $this
      */
-    public function setAggregations(AggregationInterface $aggregations): Collection
+    public function setAggregations($aggregations): Collection
     {
         $this->aggregations = $aggregations;
         return $this;
@@ -104,7 +104,7 @@ class Collection extends RemoteTemplateCollection implements SearchResultInterfa
      * @param int $totalCount
      * @return $this
      */
-    public function setTotalCount(int $totalCount): Collection
+    public function setTotalCount($totalCount): Collection
     {
         return $this;
     }


### PR DESCRIPTION
## Summary

PHP 8.4 emits a fatal error when running any admin command (e.g. `bin/magento setup:upgrade`) because `MageOS\PageBuilderTemplateImportExport\Model\ResourceModel\RemoteTemplate\Grid\Collection` declares methods with parameter type hints that are not compatible with `Magento\Framework\Api\Search\SearchResultInterface` (and its parent `SearchResultsInterface`).

```
Fatal error: Declaration of MageOS\PageBuilderTemplateImportExport\Model\ResourceModel\RemoteTemplate\Grid\Collection::setAggregations(Magento\Framework\Api\Search\AggregationInterface $aggregations): MageOS\PageBuilderTemplateImportExport\Model\ResourceModel\RemoteTemplate\Grid\Collection must be compatible with Magento\Framework\Api\Search\SearchResultInterface::setAggregations($aggregations)
```

The interface signatures have no parameter type hints:

- `SearchResultInterface::setAggregations($aggregations)`
- `SearchResultsInterface::setTotalCount($totalCount)`

Adding a type hint in the implementation (`AggregationInterface $aggregations`, `int $totalCount`) violates LSP and PHP 8.4 is strict about it.

## Fix

Drop the parameter type hints on `setAggregations` and `setTotalCount` so the signatures match the interface — same approach used in Magento core implementations (`Magento\Framework\Api\Search\SearchResult`, `Magento\Framework\Data\AbstractSearchResult`).

PHPDoc still documents the expected types, and the return type `Collection` stays (covariant return is allowed).

## Follow-up

Hi @rhoerr — could this be tagged as `1.7.1`? This is a blocking regression on PHP 8.4 installs using `1.7.0`.
