### PR TITLE
Add int return type to Console Command execute() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.8.1 - 2026-05-17
+### Fixed
+- Declare `: int` return type on `execute()` in `ExportTemplate`, `ImportTemplate`, and `UpdateRemoteTemplateList` to match `Symfony\Component\Console\Command\Command::execute()` and resolve a PHP fatal error on module load.
+
 ## 1.8.0 - 2026-04-21
 ### Fixed
 - PHP 8.4 and PHP 8.5 compatibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 1.8.1 - 2026-05-17
 ### Fixed
-- Declare `: int` return type on `execute()` in `ExportTemplate`, `ImportTemplate`, and `UpdateRemoteTemplateList` to match `Symfony\Component\Console\Command\Command::execute()` and resolve a PHP fatal error on module load.
+- Declare `: int` return type on CLI commands for compatibility with Magento 2.4.9 and Mage-OS 3.
 
 ## 1.8.0 - 2026-04-21
 ### Fixed

--- a/Console/Command/ExportTemplate.php
+++ b/Console/Command/ExportTemplate.php
@@ -73,7 +73,7 @@ class ExportTemplate extends \Symfony\Component\Console\Command\Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->setDecorated(true);
 

--- a/Console/Command/ImportTemplate.php
+++ b/Console/Command/ImportTemplate.php
@@ -40,7 +40,7 @@ class ImportTemplate extends \Symfony\Component\Console\Command\Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->setDecorated(true);
         $template = $this->templateManagement->importTemplateFromArchive($input->getOption(self::IMPORT_PATH));

--- a/Console/Command/UpdateRemoteTemplateList.php
+++ b/Console/Command/UpdateRemoteTemplateList.php
@@ -30,7 +30,7 @@ class UpdateRemoteTemplateList extends \Symfony\Component\Console\Command\Comman
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->setDecorated(true);
         try {


### PR DESCRIPTION
## Summary

The three console commands in this module override `Symfony\Component\Console\Command\Command::execute()` but did not declare the parent's `: int` return type. Under PHP 8+ signature compatibility checks this produces a fatal error at autoload time:

```
PHP Fatal error:  Declaration of MageOS\PageBuilderTemplateImportExport\Console\Command\ExportTemplate::execute(...) must be compatible with Symfony\Component\Console\Command\Command::execute(...): int
```

Fix: add the matching `: int` return type to all three commands. Each already returns `Cli::RETURN_SUCCESS` / `Cli::RETURN_FAILURE`, so no behavior changes.

Files updated:
- `Console/Command/ExportTemplate.php`
- `Console/Command/ImportTemplate.php`
- `Console/Command/UpdateRemoteTemplateList.php`

## Test plan

- [ ] Module loads on PHP 8.2/8.3/8.4 without fatal error
- [ ] `bin/magento mage-os:pagebuilder_template:export`, `:import`, and `:update_remote_template_list` continue to run and return correct exit codes